### PR TITLE
Huge improvement of ts-sql-plugin

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,7 +124,7 @@ commander
           if (n.tag.getText() === tags.sql) {
             let query_configs = fake_expression(n);
             for (const qc of query_configs) {
-              let s = qc.text.replace(/\?\?/gm, 'null');
+              let s: string = qc.text.replace(/\?\?/gm, 'null');
               let p = child_process.spawnSync(
                 _command[0],
                 _command.slice(1).concat(`EXPLAIN ${s}`),
@@ -137,7 +137,10 @@ commander
                 break;
               }
 
-              if (config.error_cost || config.warn_cost || config.info_cost) {
+              if (
+                (config.error_cost || config.warn_cost || config.info_cost) &&
+                s.trimLeft().match(/^--\s*ts-sql-plugin:ignore-cost/) == null
+              ) {
                 const stdout_str = (p.stdout.toString as any)('utf8');
                 const match = stdout_str.match(cost_pattern);
                 if (match) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,7 @@ commander
     const program = ts.createProgram(get_all_ts_files(project_path), tsconfig);
 
     const fake_expression = make_fake_expression(
-      program,
+      program.getTypeChecker(),
       tags,
     );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,7 +98,7 @@ commander
     const program = ts.createProgram(get_all_ts_files(project_path), tsconfig);
 
     const fake_expression = make_fake_expression(
-      program.getTypeChecker(),
+      program,
       tags,
     );
 

--- a/src/create.ts
+++ b/src/create.ts
@@ -73,7 +73,7 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
             // one sql`select * from person ${xxx ? sql.raw`aaa` : sql.raw`bbb`}` may generate two sqls, need to be explained one by one
             let query_configs = fake_expression(n);
             for (const qc of query_configs) {
-              let s = qc.text.replace(/\?\?/gm, 'null');
+              let s: string = qc.text.replace(/\?\?/gm, 'null');
               let p = child_process.spawnSync(
                 config.command[0],
                 config.command.slice(1).concat(`EXPLAIN ${s}`),
@@ -91,7 +91,8 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
               if (
                 [config.error_cost, config.warn_cost, config.info_cost].some(
                   it => it != void 0,
-                )
+                ) &&
+                s.trimLeft().match(/^--\s*ts-sql-plugin:ignore-cost/) == null
               ) {
                 const stdout_str = (p.stdout.toString as any)('utf8');
                 const match = stdout_str.match(cost_pattern);

--- a/src/create.ts
+++ b/src/create.ts
@@ -43,7 +43,7 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
 
           const program = info.languageService.getProgram();
           const fake_expression = make_fake_expression(
-            program,
+            program.getTypeChecker(),
             config.tags,
           );
 

--- a/src/create.ts
+++ b/src/create.ts
@@ -43,7 +43,7 @@ export function create(info: tss.server.PluginCreateInfo): tss.LanguageService {
 
           const program = info.languageService.getProgram();
           const fake_expression = make_fake_expression(
-            program.getTypeChecker(),
+            program,
             config.tags,
           );
 

--- a/src/make_fake_expression.ts
+++ b/src/make_fake_expression.ts
@@ -1,6 +1,5 @@
 import ts from 'typescript'; // used as value, passed in by tsserver at runtime
 // import tss from 'typescript/lib/tsserverlibrary'; // used as type only
-import path from 'path';
 
 import sql from './sql';
 import { is_array, deep_flatten } from './utils';

--- a/src/make_fake_expression.ts
+++ b/src/make_fake_expression.ts
@@ -16,10 +16,9 @@ export interface Tags {
 }
 
 export const make_fake_expression = (
-  program: ts.Program,
+  type_checker: ts.TypeChecker,
   tags: Tags,
 ) => {
-  const type_checker = program.getTypeChecker();
   const fns = {
     [tags.and]: sql.and,
     [tags.ins]: sql.ins,

--- a/src/make_fake_expression.ts
+++ b/src/make_fake_expression.ts
@@ -29,8 +29,60 @@ export const make_fake_expression = (
   );
   return fake_expression;
 
+  function fake_expression_from_tagged_template(n: ts.TaggedTemplateExpression) {
+    const fn = sql.raw;
+    if (n.template.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
+      return [fn(([n.template.text] as unknown) as TemplateStringsArray)];
+    }
+    if (n.template.kind === ts.SyntaxKind.TemplateExpression) {
+      const texts = ([
+        n.template.head.text,
+        ...n.template.templateSpans.map(span => span.literal.text),
+      ] as unknown) as TemplateStringsArray;
+      let values: any[][] = n.template.templateSpans
+        .map(span => fake_expression(span.expression))
+        .map(v => (is_array(v) ? deep_flatten(v) : [v]));
+
+      // * 要想编译期校验 sql, 则 sql 模板字符串内的所有有 sql.symbol 的对象都需要直接在模板字符串内定义(其实 and,ins,upd 可以不用, 只要给它们分配泛型类型就足够, 但是 raw 必须如此,
+      // * 而且就算匹配类型, 也得寻找类型原始出处, 也容易出错, 所以干脆统一要求在模板字符串内定义)...
+      // * 然后要做分支 raw, 则需要每个分支单独 explain 校验(不然肯定出错, 例如 asc desc 同时出现)...
+      // * 做分支检测最好是出现分支时, 把 texts,values 复制一份, 分支各自进行下去, 进行到最终点的时候, 自行检测, 不需要统一检测所有分支
+      // var arr = [[1],[21,22,23], [31,32], [4]];
+      // // debugger;
+      // var rs = arr.reduce((acc, cv) => {
+      //   return cv.map(v => {
+      //     return acc.map(ac => {
+      //       return ac.concat(v);
+      //     })
+      //   }).reduce((acc, cv) => acc.concat(cv), []);
+      // }, [[]]);
+      // console.table(rs);
+      // // rs should be [[1,21,31,4],[1,22,31,4],[1,23,31,4],[1,21,32,4],[1,22,32,4],[1,23,32,4]];
+
+      let all_values = values.reduce(
+        (acc, cv) => {
+          return cv
+            .map(v => acc.map(ac => ac.concat(v)))
+            .reduce((acc, cv) => acc.concat(cv), []);
+        },
+        [[]],
+      );
+      return all_values.map(_values => sql.raw(texts, ..._values));
+    }
+  }
+
   // ! fake raw``,and(),ins(),upd(),?: and other expression. sql`` is just a special kind of raw``.
   function fake_expression(n: ts.Expression) {
+    if (ts.isIdentifier(n)) {
+      const typeNode = (n as unknown as {flowNode: {node: ts.Type}}).flowNode?.node;
+      if (typeNode && (typeNode as unknown as ts.Node).kind === ts.SyntaxKind.VariableDeclaration) {
+        const childCount = typeNode.symbol.valueDeclaration.getChildCount();
+        const template = typeNode.symbol.valueDeclaration.getChildAt(childCount - 1);
+        if (ts.isTaggedTemplateExpression(template) && tag_regex.test(template.tag.getText())) {
+          return fake_expression_from_tagged_template(template);
+        }
+      }
+    }
     if (ts.isCallExpression(n)) {
       const fn = fns[(n.expression.getLastToken() || n.expression).getText()];
       if (!!fn) {
@@ -58,45 +110,7 @@ export const make_fake_expression = (
     if (ts.isTaggedTemplateExpression(n)) {
       // 因为又 sql.cond(boolean)`` 所以不能直接 n.tag.getText() === tags.xxx
       if (tag_regex.test(n.tag.getText())) {
-        const fn = sql.raw;
-        if (n.template.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
-          return [fn(([n.template.text] as unknown) as TemplateStringsArray)];
-        }
-        if (n.template.kind === ts.SyntaxKind.TemplateExpression) {
-          const texts = ([
-            n.template.head.text,
-            ...n.template.templateSpans.map(span => span.literal.text),
-          ] as unknown) as TemplateStringsArray;
-          let values: any[][] = n.template.templateSpans
-            .map(span => fake_expression(span.expression))
-            .map(v => (is_array(v) ? deep_flatten(v) : [v]));
-
-          // * 要想编译期校验 sql, 则 sql 模板字符串内的所有有 sql.symbol 的对象都需要直接在模板字符串内定义(其实 and,ins,upd 可以不用, 只要给它们分配泛型类型就足够, 但是 raw 必须如此,
-          // * 而且就算匹配类型, 也得寻找类型原始出处, 也容易出错, 所以干脆统一要求在模板字符串内定义)...
-          // * 然后要做分支 raw, 则需要每个分支单独 explain 校验(不然肯定出错, 例如 asc desc 同时出现)...
-          // * 做分支检测最好是出现分支时, 把 texts,values 复制一份, 分支各自进行下去, 进行到最终点的时候, 自行检测, 不需要统一检测所有分支
-          // var arr = [[1],[21,22,23], [31,32], [4]];
-          // // debugger;
-          // var rs = arr.reduce((acc, cv) => {
-          //   return cv.map(v => {
-          //     return acc.map(ac => {
-          //       return ac.concat(v);
-          //     })
-          //   }).reduce((acc, cv) => acc.concat(cv), []);
-          // }, [[]]);
-          // console.table(rs);
-          // // rs should be [[1,21,31,4],[1,22,31,4],[1,23,31,4],[1,21,32,4],[1,22,32,4],[1,23,32,4]];
-
-          let all_values = values.reduce(
-            (acc, cv) => {
-              return cv
-                .map(v => acc.map(ac => ac.concat(v)))
-                .reduce((acc, cv) => acc.concat(cv), []);
-            },
-            [[]],
-          );
-          return all_values.map(_values => fn(texts, ..._values));
-        }
+        return fake_expression_from_tagged_template(n);
       }
     }
     if (ts.isConditionalExpression(n)) {

--- a/src/make_fake_expression.ts
+++ b/src/make_fake_expression.ts
@@ -128,7 +128,11 @@ export const make_fake_expression = (
         }
         if (fn == sql.or) {
           const ut = t.getNumberIndexType() as ts.UnionType;
-          fake = ut.types.map(t => object_type_to_fake(t));
+          if (!!ut.types) {
+            fake = ut.types.map(t => object_type_to_fake(t));
+          } else {
+            fake = [object_type_to_fake(ut)];
+          }
         }
         return fn(fake);
       }

--- a/src/make_fake_expression.ts
+++ b/src/make_fake_expression.ts
@@ -12,6 +12,7 @@ export interface Tags {
   upd: string;
   raw: string;
   cond: string;
+  mock: string;
 }
 
 export const make_fake_expression = (
@@ -23,6 +24,7 @@ export const make_fake_expression = (
     [tags.ins]: sql.ins,
     [tags.upd]: sql.upd,
     [tags.or]: sql.or,
+    [tags.mock]: sql.mock,
   };
   const tag_regex = new RegExp(
     '^' + tags.sql + '$|' + tags.raw + '$|' + tags.cond + '\\(',
@@ -114,6 +116,16 @@ export const make_fake_expression = (
       if (!!fn) {
         const t = type_checker.getTypeAtLocation(n.arguments[0]);
         let fake: any = null;
+        if (fn == sql.mock) {
+          const argument = n.arguments && n.arguments[0] as ts.ObjectLiteralExpression;
+          if (argument) {
+            const property = argument.properties.find(p => p.name.getText() === 'mock');
+            const text: string = (<any>property)?.initializer?.text;
+            if (text) {
+              return { [sql.symbol]: true, text, values: [] };
+            }
+          }
+        }
         if (fn == sql.and || fn == sql.upd || fn == sql.ins) {
           const ut = t.getNumberIndexType() as ts.UnionType;
           if (fn == sql.ins && !!ut) {

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -92,6 +92,10 @@ sql.upd = (obj: object) => {
   return { [symbol]: true, text, values };
 };
 
+sql.mock = (obj: {mock: string, placeholder: string}) => {
+  return { [symbol]: true, text: obj.placeholder, values: [] };
+};
+
 function escape_identifier(identifier: string) {
   let [schema, table, column, operator]: string[] = ['', '', '', ''];
   [column = '', operator = '='] = identifier.replace(/"/g, '').split(' ');

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -3,7 +3,7 @@ const raw = (texts: TemplateStringsArray, ...vs: any[]) => {
   let values = [];
   vs.forEach((v, idx) => {
     if (!!v && v[symbol]) {
-      text += v.text;
+      text += v.text.replace(/\$\d+/g, '??');
       values = [...values, ...v.values];
     } else {
       text += '??';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,7 @@ export const default_tags: Tags = {
   upd: 'upd',
   raw: 'raw',
   cond: 'cond',
+  mock: 'mock'
 };
 
 export const default_cost_pattern = /\(cost=\d+\.?\d*\.\.(\d+\.?\d*)/;


### PR DESCRIPTION
Now you can use `sql` queries inside each other. Example:

```typescript
  const s1 = sql`
    select * from subscriptions.attribute where entity_id = any(${[7045]})
  `;
  const s2 = sql`
    select * from (${s1}) attr where attribute_id = any(${[7049, 7050]})
  `;
```

This is big step forward for large codebase, where `sql` queries can be shared between themselves.

Also ignore cost for query stuff implemented. Example:

```typescript
  const s1 = sql`
    -- ts-sql-plugin:ignore-cost
    select * from subscriptions.attribute
  `;
```

Via special comment at the beginning of query you can ignore cost for large queries (which often uses like DB Views and shared in other queries)