### PR TITLE
fix: occured → occurred typo in error message

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -161,7 +161,7 @@ program
               try {
                 fs.writeFileSync(filePath, s + ";");
               } catch (err) {
-                console.log(`-- Emit Error occured, when emitting file "${filePath}"`);
+                console.log(`-- Emit Error occurred, when emitting file "${filePath}"`);
               }
             }
           }


### PR DESCRIPTION
Fixes a typo in the emit command error handler output.

Before: `Emit Error occured, when emitting file ...`
After: `Emit Error occurred, when emitting file ...`
